### PR TITLE
Update for newer releases of matplotlib, datetime.

### DIFF
--- a/screensize.py
+++ b/screensize.py
@@ -65,7 +65,7 @@ def get_screen_size():
         curmon = screen.get_monitor_at_window(screen.get_active_window())
         dx, dy, width, height = screen.get_monitor_geometry(curmon)  # get geometry of current monitor
 
-    elif 'Tk' in backend:
+    elif 'Tk' in backend or 'tk' in backend:
         # We can find the fullscreen size using just Tkinter, but there is an ugly
         # side-effect. To get the size of a full screen, we need to draw a window,
         # expand it to fullscreen, retrieve the size of that window, and then remove
@@ -158,4 +158,4 @@ def get_screen_size():
 
 if __name__ == "__main__":
     w, h = get_screen_size()
-    print ('Screen size =', (w, h))
+    print ('Backend = %s, Screen size = (%d, %d)' % (plt.get_backend(), w, h))

--- a/util.py
+++ b/util.py
@@ -60,7 +60,7 @@ def thisIsWine():
             registry = ConnectRegistry(None, HKEY_LOCAL_MACHINE)
             if registry is not None:
                 try:
-                    winekey = OpenKey(registry, 'Software\Wine')
+                    winekey = OpenKey(registry, 'Software\\Wine')
                     if winekey is not None:
                         return True
                     else:


### PR DESCRIPTION
dexctrack.py :
  In version 3.7.0 of matplotlib, the number of
positional arguments for Slider was switched from
6 to 5. Logic had to be added to check the version and to handle both the older and newer forms of the Slider API.

  In version 3.9.0 of matplotlib, the return value
of avxspan was switched from polygon to rectangle. Logic had to be added to check the version, and
to handle both the old and new return forms.

  The method datetime.utcnow() is now deprecated,
and causes a warning to be output, so two calls
to it have been replaced with an alternative.

screensize.py :
  Support for the 'tkagg' backend has been added.

util.py :
  An unescaped backslash has been fixed to remove
a warning.

Resolves #17